### PR TITLE
Adding the ability to search nearby systems

### DIFF
--- a/commands/ImportController.php
+++ b/commands/ImportController.php
@@ -105,6 +105,9 @@ class ImportController extends \yii\console\Controller
 		$bench = new \Ubench;
 		$result = $bench->run(function($file, $type) {
 			$this->importJsonData($file, $type);
+
+			// Flush the system kdTree point cache
+			System::getAllPoints(true);
 		}, $file, 'systems');
 		
 		$this->stdOut("Systems import completed\n");

--- a/components/ResponseBuilder.php
+++ b/components/ResponseBuilder.php
@@ -4,6 +4,8 @@ namespace app\components;
 
 use app\models\News;
 
+use app\models\System;
+
 use yii\data\Pagination;
 use yii\web\HttpException;
 use Yii;

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "salsify/json-streaming-parser": "v4.0",
         "devster/ubench": "~1.2.0",
         "soyuka/ObjectListener": "*",
-        "yiisoft/yii2-redis": "^2.0@dev"
+        "yiisoft/yii2-redis": "^2.0@dev",
+        "sandfox/kdtree": "dev-master"
     },
     "require-dev": {
         "yiisoft/yii2-codeception": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4afdae329d5545658f18113b3ad06985",
-    "content-hash": "26d7755c26a0a25ca2c49fe0101e1933",
+    "hash": "218455d74f58a401376a4d9b1752b8a6",
+    "content-hash": "5e9b35ad55e4de0f7e6a176732455fd3",
     "packages": [
         {
             "name": "bower-asset/jquery",
@@ -513,6 +513,57 @@
                 "streaming"
             ],
             "time": "2015-03-07 19:39:22"
+        },
+        {
+            "name": "sandfox/kdtree",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sandfox/kdtree.git",
+                "reference": "ecca21a4b1f3bde18cb25e95a89cc10885d8b4de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sandfox/kdtree/zipball/ecca21a4b1f3bde18cb25e95a89cc10885d8b4de",
+                "reference": "ecca21a4b1f3bde18cb25e95a89cc10885d8b4de",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Sandfox\\KDTree\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "James Butler",
+                    "email": "james.butler@sandfox.co.uk",
+                    "homepage": "http://sandfox.co.uk"
+                },
+                {
+                    "name": "Michael Fairhurst",
+                    "email": "michaelrfairhurst@gmail.com",
+                    "homepage": "http://wakelang.com"
+                }
+            ],
+            "description": "A slow and possibly buggy implementation of a kdtree in php",
+            "homepage": "https://github.com/sandfox/kdtree",
+            "keywords": [
+                "bsp",
+                "geospatial",
+                "kdtree"
+            ],
+            "time": "2014-06-02 16:45:10"
         },
         {
             "name": "soyuka/ObjectListener",
@@ -1066,7 +1117,8 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "yiisoft/yii2-redis": 20
+        "yiisoft/yii2-redis": 20,
+        "sandfox/kdtree": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/config/web.php
+++ b/config/web.php
@@ -61,13 +61,17 @@ $config = [
                     'route' => 'systems/view'
                 ],
                 [
+                    'pattern' => '/systems/<id:\d+>/nearby',
+                    'route' => 'systems/nearby'
+                ],
+                [
                     'pattern' => '/stations',
                     'route' => 'stations/index'
                 ],
                 [
                     'pattern' => '/stations/<id:\d+>',
                     'route' => 'stations/view'
-                ],
+                ]
             ]
         ],
         'log' => [

--- a/controllers/SystemsController.php
+++ b/controllers/SystemsController.php
@@ -64,4 +64,22 @@ class SystemsController extends \yii\rest\Controller
 		$query = System::find()->where(['id' => $id]);
 		return ResponseBuilder::build($query, 'systems', Yii::$app->request->get('sort', 'name'), Yii::$app->request->get('order', 'asc'));
 	}
+
+	public function actionNearby($id=NULL)
+	{
+		$response = [];
+
+		if ($id === NULL)
+			throw new HttpException(400, 'Missing ID parameter');
+
+		$model = System::find()->where(['id' => $id])->one();
+
+		if ($model === NULL)
+			throw new HttpException(400, 'Invalid system ID');
+
+		$response = $model->getNearbySystems();
+
+		$query = System::find()->where(['in', 'id', $response]);
+		return ResponseBuilder::build($query, 'systems');
+	}
 }

--- a/docs/systems.md
+++ b/docs/systems.md
@@ -94,6 +94,8 @@ Feel free to mix and match multiple query parameters for complex searches. Data 
 }
 ```
 
+# System details by ID
+
 To see information for a specific system, request that system directly using it's ```id```
 
 ```
@@ -101,3 +103,20 @@ GET /systems/100
 ```
 
 > Note: the systems endpoint does not show all information for a station. To view more information about a station, request that station directly
+
+# Nearby Systems
+
+GNA can also show the closest 15 systems to a given system by it's ID by issuing the following request
+
+```
+GET /systems/<id>/nearby
+```
+
+## Examples
+
+```
+GET /systems/11065/nearby # Systems near Kou Hua
+GET /systems/16916/nearby # Systems near Sif
+```
+
+> Note, building the kdTree necessary to display this information is extremely time consuming. Consequently, nearby system data is data is only cleared on import.


### PR DESCRIPTION
GNA can show nearby system information

```
GET /system/<id>/nearby
```

Outstanding tasks:
- Current kdTree implementation is _not_ memory friendly
